### PR TITLE
Explicit link to pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_CXX_EXTENSIONS ON)
 #target_link_libraries(support PUBLIC -lh2o-evloop -lssl -lcrypto Threads::Threads)
 
 add_executable(teller teller.cc )
-target_link_libraries(teller -lpcaudio)
+target_link_libraries(teller -lpcaudio -lpthread)
 
 #enable_testing()
 #add_test(testname testrunner)


### PR DESCRIPTION
Fixes:

    $ LC_ALL=C make                                                                                                      
    [ 50%] Linking CXX executable teller                      
    /usr/bin/ld: CMakeFiles/teller.dir/teller.cc.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'         
    /usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line             
    collect2: error: ld returned 1 exit status    
    make[2]: *** [CMakeFiles/teller.dir/build.make:103: teller] Error 1                                                                                                                                                                     
    make[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/teller.dir/all] Error 2                                                                                                                                                               
    make: *** [Makefile:103: all] Error 2